### PR TITLE
Relax: emit a warning and ignore HTTP2 streams that lack a request substream, instead of raising

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pcapng-utils (1.1.1) bookworm; urgency=medium
+
+  * Relax: emit a warning and ignore HTTP2 streams that lack a request substream, instead of raising
+
+ -- emaheuxPEREN <contact@peren.gouv.fr> Thu, 23 Apr 2026 19:34:13 +0200
+
 pcapng-utils (1.1.0) bookworm; urgency=medium
 
   * Feat: Support WebSocket protocol

--- a/pcapng_utils/tshark/protocols/http2.py
+++ b/pcapng_utils/tshark/protocols/http2.py
@@ -1,4 +1,5 @@
 import warnings
+import logging
 from functools import cached_property
 from collections.abc import Set, Sequence, Mapping
 from typing import ClassVar, Optional, Any
@@ -7,6 +8,8 @@ from ...payload import Payload
 from ..types import HarEntry, DictLayers, NameValueDict
 from ..layers import FrameMixin, TCPIPMixin, get_protocols, get_har_communication, get_tcp_stream_id, get_community_id
 from ..utils import get_tshark_bytes_from_raw, har_entry_with_common_fields
+
+LOGGER = logging.getLogger(__name__)
 
 
 class Http2Substream(FrameMixin, TCPIPMixin):
@@ -247,11 +250,10 @@ class Http2Stream:
 
         :return: the HAR entry for the HTTP2 stream
         """
-        assert self.request is not None, self.id
-        assert self.response is not None, self.id
-        if not self.request:
+        if not self.request:  # may happen if we failed to find request among substreams
             assert not self.response, self.id
             return None
+        assert self.response is not None, self.id
         first_stream = self.request.headers_streams[0]
         return har_entry_with_common_fields({
             '_timestamp': first_stream.timestamp,
@@ -332,13 +334,20 @@ class Http2Stream:
             if 'http2.request.full_uri' in substream.raw_http2_substream:  # This is a request
                 src, dst = substream.src_ip_port, substream.dst_ip_port
                 break
-        assert src and dst, self.substreams
-        assert src != dst, src
+        if not (src and dst):
+            LOGGER.warning(
+                f"Ignoring HTTP2 stream {self.id} which is lacking a request, "
+                f"substreams types = {[ss.http2_type for ss in self.substreams]}"
+            )
+            return
+        assert src != dst, (self.id, src)
 
         # Create the request and response objects with their associated substreams
         req_substreams = [substream for substream in self.substreams if substream.src_ip_port == src]
         resp_substreams = [substream for substream in self.substreams if substream.src_ip_port == dst]
-        assert len(req_substreams) + len(resp_substreams) == len(self.substreams), self.substreams
+        assert len(req_substreams) + len(resp_substreams) == len(self.substreams), (
+            self.id, len(self.substreams), len(req_substreams), len(resp_substreams)
+        )
         self.request = Http2Request(req_substreams)
         self.response = Http2Response(resp_substreams)  # may be empty
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ namespaces = false
 
 [project]
 name = "pcapng-utils"
-version = "1.1.0"
+version = "1.1.1"
 description = "A set of Python scripts to manipulate PCAPNG files"
 readme = "README.md"
 license = {text = "GPL-3.0+ AND MIT"}


### PR DESCRIPTION
This situation was encountered in some cases, we warn to be able to produce HAR despite this non-fatal issue 